### PR TITLE
Improve accessibility of navigation and podcast iframe

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -29,12 +29,12 @@
 <body class="bg-drek-bg text-drek-muted font-body leading-relaxed m-0">
   <header class="bg-black p-4 border-b-2 border-drek-gold text-center">
     <h1 class="font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
-    <nav>
+    <nav aria-label="Main navigation">
       <ul class="list-none p-0 mt-4 flex flex-col sm:flex-row justify-center flex-wrap gap-4">
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="/index.html">Home</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="/world.html">World</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="/characters.html">Characters</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="/podcast.html">Podcast</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="/index.html">Home</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="/world.html">World</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="/characters.html">Characters</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="/podcast.html">Podcast</a></li>
       </ul>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -29,12 +29,12 @@
 <body class="bg-drek-bg text-drek-muted font-body leading-relaxed m-0">
   <header class="bg-black p-4 border-b-2 border-drek-gold text-center">
     <h1 class="font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
-    <nav>
+    <nav aria-label="Main navigation">
       <ul class="list-none p-0 mt-4 flex flex-col sm:flex-row justify-center flex-wrap gap-4">
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="/index.html">Home</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="/world.html">World</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="#">Characters</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="/podcast.html">Podcast</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="/index.html">Home</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="/world.html">World</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="#">Characters</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="/podcast.html">Podcast</a></li>
       </ul>
     </nav>
   </header>

--- a/podcast.html
+++ b/podcast.html
@@ -29,12 +29,12 @@
 <body class="bg-drek-bg text-drek-muted font-body leading-relaxed m-0">
   <header class="bg-black p-4 border-b-2 border-drek-gold text-center">
     <h1 class="font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
-    <nav>
+    <nav aria-label="Main navigation">
       <ul class="list-none p-0 mt-4 flex flex-col sm:flex-row justify-center flex-wrap gap-4">
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="index.html">Home</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="world.html">World</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="#">Characters</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="podcast.html">Podcast</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="index.html">Home</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="world.html">World</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="#">Characters</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="podcast.html">Podcast</a></li>
       </ul>
     </nav>
   </header>
@@ -44,7 +44,7 @@
       <h2 class="font-medieval text-3xl text-yellow-300 mb-4">Chronicles of Drekoria</h2>
       <p class="max-w-2xl mx-auto text-lg">The main audio story of Drekoria. Follow the journey of Vatakh, a boy raised by the wild and shaped by the shadows of a crumbling world. An immersive tale of mystery, brotherhood, and survival.</p>
       <div class="player mt-4">
-        <iframe style="border-radius:12px" src="https://open.spotify.com/embed/show/exampleChronicles" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+        <iframe title="Chronicles of Drekoria episode" style="border-radius:12px" src="https://open.spotify.com/embed/show/exampleChronicles" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
       </div>
     </section>
 
@@ -52,7 +52,7 @@
       <h2 class="font-medieval text-3xl text-yellow-300 mb-4">The Voice of Drekoria</h2>
       <p class="max-w-2xl mx-auto text-lg">Historical insights and forgotten legends from Drekoria and beyond. A companion series uncovering real-world myths and fantasy lore to inspire the world behind the tale.</p>
       <div class="player mt-4">
-        <iframe style="border-radius:12px" src="https://open.spotify.com/embed/show/exampleVoice" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+        <iframe title="The Voice of Drekoria episode" style="border-radius:12px" src="https://open.spotify.com/embed/show/exampleVoice" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
       </div>
     </section>
   </main>

--- a/world.html
+++ b/world.html
@@ -29,12 +29,12 @@
 <body class="bg-drek-bg text-drek-muted font-body leading-relaxed m-0">
   <header class="bg-black p-4 border-b-2 border-drek-gold text-center">
     <h1 class="font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
-    <nav>
+    <nav aria-label="Main navigation">
       <ul class="list-none p-0 mt-4 flex flex-col sm:flex-row justify-center flex-wrap gap-4">
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="index.html">Home</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="world.html">World</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="#">Characters</a></li>
-        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="podcast.html">Podcast</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="index.html">Home</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="world.html">World</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="#">Characters</a></li>
+        <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors focus:outline-none focus:ring-2 focus:ring-drek-gold" href="podcast.html">Podcast</a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- add `aria-label` to all `<nav>` elements
- add focus ring styles to navigation links
- include `title` attributes for podcast iframes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685480604e7c8333855650aee4044dc9