### PR TITLE
Add glow and fade-in animations

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -25,10 +25,16 @@
       }
     }
   </script>
+  <style>
+    @layer utilities {
+      @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+      @keyframes glow { 0%,100% { text-shadow: 0 0 10px #d4af37; } 50% { text-shadow: 0 0 20px #d4af37; } }
+    }
+  </style>
 </head>
 <body class="bg-drek-bg text-drek-muted font-body leading-relaxed m-0">
   <header class="bg-black p-4 border-b-2 border-drek-gold text-center">
-    <h1 class="font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
+    <h1 class="animate-[glow_2s_infinite] font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
     <nav>
       <ul class="list-none p-0 mt-4 flex flex-col sm:flex-row justify-center flex-wrap gap-4">
         <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="/index.html">Home</a></li>
@@ -41,7 +47,7 @@
 
   <main>
     <section class="bg-gray-900 py-16 px-8 text-center border-y border-gray-700">
-      <h2 class="font-medieval text-3xl text-yellow-300 mb-4">Characters of Drekoria</h2>
+      <h2 class="animate-[fade-in_1s_ease-in] font-medieval text-3xl text-yellow-300 mb-4">Characters of Drekoria</h2>
       <p class="max-w-2xl mx-auto text-lg">Meet the key figures whose choices shape the fate of the known world.</p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -25,10 +25,16 @@
       }
     }
   </script>
+  <style>
+    @layer utilities {
+      @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+      @keyframes glow { 0%,100% { text-shadow: 0 0 10px #d4af37; } 50% { text-shadow: 0 0 20px #d4af37; } }
+    }
+  </style>
 </head>
 <body class="bg-drek-bg text-drek-muted font-body leading-relaxed m-0">
   <header class="bg-black p-4 border-b-2 border-drek-gold text-center">
-    <h1 class="font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
+    <h1 class="animate-[glow_2s_infinite] font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
     <nav>
       <ul class="list-none p-0 mt-4 flex flex-col sm:flex-row justify-center flex-wrap gap-4">
         <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="/index.html">Home</a></li>
@@ -41,7 +47,7 @@
 
   <main>
     <section class="bg-gray-900 py-16 px-8 text-center border-y border-gray-700">
-      <h2 class="font-medieval text-3xl text-yellow-300 mb-4">A World Beyond Time</h2>
+      <h2 class="animate-[fade-in_1s_ease-in] font-medieval text-3xl text-yellow-300 mb-4">A World Beyond Time</h2>
       <p class="max-w-2xl mx-auto text-lg">Welcome to Drekoria — a land of forgotten legends, hidden powers, and ancient ruins. Your journey begins here.</p>
     </section>
   </main>

--- a/podcast.html
+++ b/podcast.html
@@ -25,10 +25,16 @@
       }
     }
   </script>
+  <style>
+    @layer utilities {
+      @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+      @keyframes glow { 0%,100% { text-shadow: 0 0 10px #d4af37; } 50% { text-shadow: 0 0 20px #d4af37; } }
+    }
+  </style>
 </head>
 <body class="bg-drek-bg text-drek-muted font-body leading-relaxed m-0">
   <header class="bg-black p-4 border-b-2 border-drek-gold text-center">
-    <h1 class="font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
+    <h1 class="animate-[glow_2s_infinite] font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
     <nav>
       <ul class="list-none p-0 mt-4 flex flex-col sm:flex-row justify-center flex-wrap gap-4">
         <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="index.html">Home</a></li>
@@ -41,7 +47,7 @@
 
   <main>
     <section class="bg-gray-900 py-16 px-8 text-center border-y border-gray-700">
-      <h2 class="font-medieval text-3xl text-yellow-300 mb-4">Chronicles of Drekoria</h2>
+      <h2 class="animate-[fade-in_1s_ease-in] font-medieval text-3xl text-yellow-300 mb-4">Chronicles of Drekoria</h2>
       <p class="max-w-2xl mx-auto text-lg">The main audio story of Drekoria. Follow the journey of Vatakh, a boy raised by the wild and shaped by the shadows of a crumbling world. An immersive tale of mystery, brotherhood, and survival.</p>
       <div class="player mt-4">
         <iframe style="border-radius:12px" src="https://open.spotify.com/embed/show/exampleChronicles" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
@@ -49,7 +55,7 @@
     </section>
 
     <section class="bg-gray-900 py-16 px-8 text-center border-b border-gray-700">
-      <h2 class="font-medieval text-3xl text-yellow-300 mb-4">The Voice of Drekoria</h2>
+      <h2 class="animate-[fade-in_1s_ease-in] font-medieval text-3xl text-yellow-300 mb-4">The Voice of Drekoria</h2>
       <p class="max-w-2xl mx-auto text-lg">Historical insights and forgotten legends from Drekoria and beyond. A companion series uncovering real-world myths and fantasy lore to inspire the world behind the tale.</p>
       <div class="player mt-4">
         <iframe style="border-radius:12px" src="https://open.spotify.com/embed/show/exampleVoice" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>

--- a/world.html
+++ b/world.html
@@ -25,10 +25,16 @@
       }
     }
   </script>
+  <style>
+    @layer utilities {
+      @keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+      @keyframes glow { 0%,100% { text-shadow: 0 0 10px #d4af37; } 50% { text-shadow: 0 0 20px #d4af37; } }
+    }
+  </style>
 </head>
 <body class="bg-drek-bg text-drek-muted font-body leading-relaxed m-0">
   <header class="bg-black p-4 border-b-2 border-drek-gold text-center">
-    <h1 class="font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
+    <h1 class="animate-[glow_2s_infinite] font-medieval text-4xl text-drek-gold m-0">Drekoria</h1>
     <nav>
       <ul class="list-none p-0 mt-4 flex flex-col sm:flex-row justify-center flex-wrap gap-4">
         <li><a class="no-underline text-drek-muted py-2 px-4 border border-drek-gold rounded hover:bg-drek-gold hover:text-black transition-colors" href="index.html">Home</a></li>
@@ -41,12 +47,12 @@
 
   <main>
     <section class="bg-gray-900 py-16 px-8 text-center border-y border-gray-700">
-      <h2 class="font-medieval text-3xl text-yellow-300 mb-4">The Known World</h2>
+      <h2 class="animate-[fade-in_1s_ease-in] font-medieval text-3xl text-yellow-300 mb-4">The Known World</h2>
       <p class="max-w-2xl mx-auto text-lg">Drekoria is the only known continent in its world — vast, ancient, and shaped by the rise and fall of empires. Its people believe it to be all that exists, though myths whisper of lands beyond the horizon.</p>
     </section>
 
     <section class="bg-gray-900 py-16 px-8 text-center border-b border-gray-700">
-      <h2 class="font-medieval text-3xl text-yellow-300 mb-4">Fragments of History</h2>
+      <h2 class="animate-[fade-in_1s_ease-in] font-medieval text-3xl text-yellow-300 mb-4">Fragments of History</h2>
       <p class="max-w-2xl mx-auto text-lg">Once ruled by dragons, later unified under a single empire, Drekoria is now a land of fractured kingdoms and forgotten oaths. Magic is fading, but not gone. The ruins speak of a time when power flowed through the stones and skies alike.</p>
     </section>
 


### PR DESCRIPTION
## Summary
- add `fade-in` and `glow` keyframes via `@layer utilities`
- apply subtle glow and fade-in animations to headings across pages

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854805b65d08333b3389c27996af752