### PR TITLE
Update CMS config for GitHub OAuth

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,6 +2,7 @@ backend:
   name: github
   repo: I2KGhost/drekoria.com
   branch: main
+  app_id: Ov23li2rwPhQy32jeLym
 
 media_folder: "assets/uploads"
 public_folder: "/assets/uploads"


### PR DESCRIPTION
## Summary
- enable GitHub OAuth login by setting `app_id` in the CMS backend

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549c0f46c4833390a07a324961b5c2