### PR TITLE
Add character card styling

### DIFF
--- a/characters.html
+++ b/characters.html
@@ -25,6 +25,7 @@
       }
     }
   </script>
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body class="bg-drek-bg text-drek-muted font-body leading-relaxed m-0" data-page="characters">
   <header class="bg-black border-b-2 border-drek-gold p-4 text-center">
@@ -46,22 +47,22 @@
     </section>
 
     <section class="px-8 py-12 grid gap-8 max-w-4xl mx-auto">
-      <div class="bg-gray-800 p-4 rounded border border-gray-700">
+      <div class="character-card">
         <h3 class="font-medieval text-2xl text-drek-gold mb-2">Vatah</h3>
         <p>A boy raised in the wild, now caught between destiny and survival. Trained in the fortress of Velstone.</p>
       </div>
 
-      <div class="bg-gray-800 p-4 rounded border border-gray-700">
+      <div class="character-card">
         <h3 class="font-medieval text-2xl text-drek-gold mb-2">Dalemir</h3>
         <p>A hunter with a mysterious past. Stoic, wise, and the one who raised Vatah.</p>
       </div>
 
-      <div class="bg-gray-800 p-4 rounded border border-gray-700">
+      <div class="character-card">
         <h3 class="font-medieval text-2xl text-drek-gold mb-2">Lev</h3>
         <p>A young blacksmith’s apprentice and Vatah’s only true friend. Loyal and brave.</p>
       </div>
 
-      <div class="bg-gray-800 p-4 rounded border border-gray-700">
+      <div class="character-card">
         <h3 class="font-medieval text-2xl text-drek-gold mb-2">Marek</h3>
         <p>Ambitious and proud. Once an ally, now a rival within the brotherhood.</p>
       </div>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,11 @@
+/* Custom styles for Drekoria */
+
+.character-card {
+  background-color: #1f2937; /* gray-800 */
+  border: 1px solid #374151; /* gray-700 */
+  border-radius: 0.375rem; /* rounded */
+  padding: 1rem; /* p-4 */
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- create `style.css` for custom styles
- style character profiles via `.character-card` class
- apply the new class to characters page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854993e3f2c83338ae82dbfce417ef9