### PR TITLE
Add HTML lint check with GitHub Actions

### DIFF
--- a/.github/workflows/html_lint.yml
+++ b/.github/workflows/html_lint.yml
@@ -1,0 +1,14 @@
+name: HTML Lint
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run lint:html

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "drekoria-site",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "glob": "^10.3.10",
+    "htmlhint": "^1.1.4"
+  },
+  "scripts": {
+    "lint:html": "node scripts/html_check.js"
+  }
+}

--- a/scripts/html_check.js
+++ b/scripts/html_check.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const glob = require('glob');
+const { HTMLHint } = require('htmlhint');
+
+const files = glob.sync('**/*.html', { ignore: ['node_modules/**'] });
+let errorCount = 0;
+
+files.forEach(file => {
+  const html = fs.readFileSync(file, 'utf8');
+  const messages = HTMLHint.verify(html);
+  if (messages.length > 0) {
+    console.log(`\n${file}`);
+    messages.forEach(m => {
+      console.log(`${file}:${m.line}:${m.col} [${m.rule.id}] ${m.message}`);
+      errorCount += 1;
+    });
+  }
+});
+
+if (errorCount > 0) {
+  console.error(`\nHTMLHint found ${errorCount} error(s).`);
+  process.exit(1);
+} else {
+  console.log('All HTML files pass HTMLHint.');
+}


### PR DESCRIPTION
## Summary
- add htmlhint-based linting script
- configure GitHub Actions to run the script on every push
- define dev dependencies with package.json

## Testing
- `npm run lint:html` *(fails: Cannot find module 'glob')*

------
https://chatgpt.com/codex/tasks/task_e_68549905062c8333aedca2abbc6ee87b